### PR TITLE
Resolve pkgbuild deps between split packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aur-depends"
 version = "4.0.3"
 authors = ["morganamilo <m?organamilo@gmail.com>"]
-edition = "2021"
+edition = "2024"
 
 description = "A libary for resolving aur dependencies"
 homepage = "https://github.com/Morganamilo/aur-depends"

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,4 +1,4 @@
-use crate::{satisfies::Satisfies, Base};
+use crate::{Base, satisfies::Satisfies};
 
 use std::collections::{HashMap, HashSet};
 


### PR DESCRIPTION
When resolving deps, if the package is split and package A depends on package B. if package B happened to also exist in the repos then we would pick the dep from there instead of the pkgbuild.

This leads to issues when trying to resolve A and B as we end up with B getting pulled from the repos and we end up with duplicate packages.