### PR TITLE
Compatible with Rust 2024 Edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ features = [ "docs-rs" ]
 alpm = "5.0.2"
 alpm-utils = "5.0.0"
 log = "0.4.29"
-raur = { version = "7.0.0", default-features = false, features = ["async"] }
+raur = { version = "8.0.0", default-features = false, features = ["async"] }
 bitflags = "2.10.0"
 srcinfo = "2.0.0"
 
@@ -31,7 +31,7 @@ tokio = { version = "1.48.0", features = ["macros", "rt"] }
 [features]
 git = ["alpm/git", "alpm-utils/git"]
 generate = ["alpm/generate", "alpm-utils/generate"]
-rustls-tls = ["raur/rustls-tls"]
+rustls-tls = ["raur/rusttls-tls"]
 docs-rs = ["alpm/docs-rs"]
 default = ["raur/default"]
 


### PR DESCRIPTION
Once the raur update is adopted and the version number is updated to 8.0.0, we can support Rust 2024 Edition by updating the raur version to 8.0.0 in both paru and aur-depends.

https://github.com/Morganamilo/paru/pull/1500  
https://gitlab.com/davidbittner/raur/-/merge_requests/30
